### PR TITLE
Fixed biomes only changing in one axis.

### DIFF
--- a/Section_3_Scripts/TerrainGenerator.cs
+++ b/Section_3_Scripts/TerrainGenerator.cs
@@ -109,7 +109,7 @@ public class TerrainGenerator : MonoBehaviour
     private List<float> CalculateBiomeNoise(List<Vector3Int> biomeCenters, Vector2Int mapSeedOffset)
     {
         biomeNoiseSettings.worldOffset = mapSeedOffset;
-        return biomeCenters.Select(center => MyNoise.OctavePerlin(center.x, center.y, biomeNoiseSettings)).ToList();
+        return biomeCenters.Select(center => MyNoise.OctavePerlin(center.x, center.z, biomeNoiseSettings)).ToList();
     }
 
     private void OnDrawGizmos()


### PR DESCRIPTION
In the TerraingGenerator we were calculating the octave perlin with the X and Y coordinates instead of X and Z causing to only change the biomes in the X anxis. Sorry for my english.